### PR TITLE
Allow output to a stream (eg: process.stdout)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,7 @@ See [test/server.js][server.js] for an example of a very simple Hapi server that
 
 ## Configuration
 
-Usually, you can set the reporter `config` value to the path to your log file,
-or to an existing stream (eg: console.stdout). Hapi will now automatically
-append logs to that file/stream, and for a file if you send a `HUP` signal to your server, it will re-open that file.
+Usually, you can set the reporter `config` value to the path to your log file, or to an existing stream (eg: console.stdout). Hapi will now automatically append logs to that file/stream, and for a file if you send a `HUP` signal to your server, it will re-open that file.
 
 However, for more detailed control, `config` can be an object with these keys:
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,13 @@ See [test/server.js][server.js] for an example of a very simple Hapi server that
 
 ## Configuration
 
-Usually, you can set the reporter `config` value to the path to your log file. Hapi will now automatically append logs to that file, and if you send a `HUP` signal to your server, it will re-open that file.
+Usually, you can set the reporter `config` value to the path to your log file,
+or to an existing stream (eg: console.stdout). Hapi will now automatically
+append logs to that file/stream, and for a file if you send a `HUP` signal to your server, it will re-open that file.
 
 However, for more detailed control, `config` can be an object with these keys:
 
-* **file** - The path to the log file
+* **file** - The path to the log file, or an existing stream
 * **format** - The log format to use, default is `"combined"`; see [Log Formats](#log-formats) below
 * **separator** - The separator between log lines, default is `"\n"`
 * **hup** - Boolean; if `true`, Good-Apache-Log will listen to `SIGHUP` and re-open its log file; default is `true`

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var Squeeze = require('good-squeeze').Squeeze;
 var LogFormat = require('./format.js')
 
 var DEFAULTS = {format:'combined', separator:'\n', hup:true}
-var SinkSchema = [Joi.string().required(), Joi.object().type(Stream.Stream)];
+var SinkSchema = [Joi.string().required(), Joi.object().type(Stream.Stream).required()];
 var OptionsSchema = Joi.alternatives().try(
   SinkSchema,
   Joi.object().keys({

--- a/index.js
+++ b/index.js
@@ -13,10 +13,11 @@ var Squeeze = require('good-squeeze').Squeeze;
 var LogFormat = require('./format.js')
 
 var DEFAULTS = {format:'combined', separator:'\n', hup:true}
+var SinkSchema = [Joi.string().required(), Joi.object().type(Stream.Stream)];
 var OptionsSchema = Joi.alternatives().try(
-  Joi.string(),
+  SinkSchema,
   Joi.object().keys({
-    file  : Joi.string().required(),
+    file  : SinkSchema,
     format: Joi.string(),
     separator: Joi.string(),
     hup: Joi.boolean()
@@ -33,10 +34,10 @@ function GoodApacheLog (events, config) {
   config = config || false
   Joi.assert(config, OptionsSchema, 'Invalid options');
 
-  if (typeof config == 'string')
+  if (typeof config == 'string' || config instanceof Stream.Stream)
     config = { file: config }
 
-  this._settings = Hoek.applyToDefaults(DEFAULTS, config)
+  this._settings = Hoek.applyToDefaultsWithShallow(DEFAULTS, config, ['file'])
   debug('Settings: %j', this._settings)
 
   // Only process "response" events.
@@ -80,6 +81,9 @@ GoodApacheLog.prototype.init = function (stream, emitter, callback) {
 GoodApacheLog.prototype._buildWriteStream = function () {
   var self = this
   debug('buildWriteStream')
+
+  if (self._settings.file instanceof Stream.Stream)
+    return self._settings.file;
 
   var result = fs.createWriteStream(self._settings.file, {flags:'a', end:false, encoding:'utf8'})
   result.once('error', function (er) {


### PR DESCRIPTION
Allows 'file' option to be an existing stream, useful for environments like Docker containers
  (option not renamed for backwards compatibility)